### PR TITLE
fix(Element): `outerHtmlHead` should not indent inline elements

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -1217,8 +1217,21 @@ open class Element: Node {
         return self
     }
 
+    private func isFormatAsBlock(_ out: OutputSettings) -> Bool {
+        return _tag.isBlock() || parent()?.tag().formatAsBlock() == true || out.outline()
+    }
+
+    private func isInlineable(_ out: OutputSettings) -> Bool {
+        guard _tag.isInline() else { return false }
+        return parent()?.isBlock() == true && !isEffectivelyFirst() && !out.outline() && !isNode("br")
+    }
+
+    private func shouldIndent(_ out: OutputSettings) -> Bool {
+        return out.prettyPrint() && isFormatAsBlock(out) && !isInlineable(out)
+    }
+
     override func outerHtmlHead(_ accum: StringBuilder, _ depth: Int, _ out: OutputSettings)throws {
-        if (out.prettyPrint() && (_tag.formatAsBlock() || (parent() != nil && parent()!.tag().formatAsBlock()) || out.outline())) {
+        if shouldIndent(out) {
             if !accum.isEmpty {
                 indent(accum, depth, out)
             }

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -1217,6 +1217,22 @@ open class Element: Node {
         return self
     }
 
+    private static func preserveWhitespace(of node: Node?) -> Bool {
+        // looks only at this element and five levels up, to prevent recursion & needless stack searches
+        var currentElement = node as? Element
+        for _ in 0...5 {
+            guard let element = currentElement else { return false }
+
+            if element._tag.preserveWhitespace() {
+                return true
+            } else {
+                currentElement = element.parent()
+            }
+        }
+
+        return false
+    }
+
     private func isFormatAsBlock(_ out: OutputSettings) -> Bool {
         return _tag.isBlock() || parent()?.tag().formatAsBlock() == true || out.outline()
     }
@@ -1227,7 +1243,7 @@ open class Element: Node {
     }
 
     private func shouldIndent(_ out: OutputSettings) -> Bool {
-        return out.prettyPrint() && isFormatAsBlock(out) && !isInlineable(out)
+        return out.prettyPrint() && isFormatAsBlock(out) && !isInlineable(out) && !Self.preserveWhitespace(parentNode)
     }
 
     override func outerHtmlHead(_ accum: StringBuilder, _ depth: Int, _ out: OutputSettings)throws {

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -59,6 +59,22 @@ open class Node: Equatable, Hashable {
         preconditionFailure("This method must be overridden")
     }
 
+    public func isNode(_ name: String) -> Bool {
+        return nodeName() == name
+    }
+
+    public func isEffectivelyFirst() -> Bool {
+        if siblingIndex == 0 {
+            return true
+        } else if siblingIndex == 1 {
+            let previousSibling = previousSibling()
+            guard let textNode = previousSibling as? TextNode else { return false }
+            return textNode.isBlank()
+        } else {
+            return false
+        }
+    }
+
     /**
      * Get an attribute's value by its key. <b>Case insensitive</b>
      * <p>


### PR DESCRIPTION
Same logic here: https://github.com/jhy/jsoup/blob/master/src/main/java/org/jsoup/nodes/Element.java#L1724